### PR TITLE
Add support for immutable root reducer

### DIFF
--- a/src/immutable/index.js
+++ b/src/immutable/index.js
@@ -1,0 +1,13 @@
+import {
+  createResource as baseCreateResource,
+  readEndpoint as baseReadEndpoint,
+  updateResource as baseUpdateResource,
+  deleteResource as baseDeleteResource,
+  requireResource as baseRequireResource,
+} from '../jsonapi';
+
+export const createResource = resource => baseCreateResource(resource, state => state.get('api'));
+export const readEndpoint = (endpoint, options) => baseReadEndpoint(endpoint, options, state => state.get('api'));
+export const updateResource = resource => baseUpdateResource(resource, state => state.get('api'));
+export const deleteResource = resource => baseDeleteResource(resource, state => state.get('api'));
+export const requireResource = (resourceType, endpoint) => baseRequireResource(resourceType, endpoint, state => state.get('api'));

--- a/src/jsonapi.js
+++ b/src/jsonapi.js
@@ -39,11 +39,11 @@ const apiWillDelete = createAction(API_WILL_DELETE);
 const apiDeleted = createAction(API_DELETED);
 const apiDeleteFailed = createAction(API_DELETE_FAILED);
 
-export const createResource = (resource) => {
+export const createResource = (resource, apiState = state => state.api) => {
   return (dispatch, getState) => {
     dispatch(apiWillCreate(resource));
 
-    const { axiosConfig } = getState().api.endpoint;
+    const { axiosConfig } = apiState(getState()).endpoint;
     const options = {
       ... axiosConfig,
       method: 'POST',
@@ -86,11 +86,11 @@ export const readEndpoint = (endpoint, {
   options = {
     indexLinks: undefined,
   }
-} = {}) => {
+} = {}, apiState = state => state.api) => {
   return (dispatch, getState) => {
     dispatch(apiWillRead(endpoint));
 
-    const { axiosConfig } = getState().api.endpoint;
+    const { axiosConfig } = apiState(getState()).endpoint;
 
     return new Promise((resolve, reject) => {
       apiRequest(endpoint, axiosConfig)
@@ -113,11 +113,11 @@ export const readEndpoint = (endpoint, {
   };
 };
 
-export const updateResource = (resource) => {
+export const updateResource = (resource, apiState = state => state.api) => {
   return (dispatch, getState) => {
     dispatch(apiWillUpdate(resource));
 
-    const { axiosConfig } = getState().api.endpoint;
+    const { axiosConfig } = apiState(getState()).endpoint;
     const endpoint = `${resource.type}/${resource.id}`;
 
     const options = {
@@ -145,11 +145,11 @@ export const updateResource = (resource) => {
   };
 };
 
-export const deleteResource = (resource) => {
+export const deleteResource = (resource, apiState = state => state.api) => {
   return (dispatch, getState) => {
     dispatch(apiWillDelete(resource));
 
-    const { axiosConfig } = getState().api.endpoint;
+    const { axiosConfig } = apiState(getState()).endpoint;
     const endpoint = `${resource.type}/${resource.id}`;
 
     const options = {
@@ -174,10 +174,10 @@ export const deleteResource = (resource) => {
   };
 };
 
-export const requireResource = (resourceType, endpoint = resourceType) => {
+export const requireResource = (resourceType, endpoint = resourceType, apiState = state => state.api) => {
   return (dispatch, getState) => {
     return new Promise((resolve, reject) => {
-      const { api } = getState();
+      const api = apiState(getState());
       if (api.hasOwnProperty(resourceType)) {
         resolve();
       }


### PR DESCRIPTION
I know this has already been discussed at least here #80 and #81 .

I took a different approach from #81 to keep the core of the library agnostic regarding how the state is managed.

I did something very simple, this idea when having a root reducer immutable would be to import actions from `redux-json-api/immutable` instead of `redux-json-api`. 

If you would be okay to integrate this, I could add documentation and some tests, I think it's important to let the developers use whatever root reducer they want.