### PR TITLE
Multiple instances/Request option caching in redux  for middleware customisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "axios": "^0.13.1",
     "deep-equal": "^1.0.1",
     "keykey": "^2.1.1",
+    "lodash.uniqueid": "^4.0.1",
     "object-path-immutable": "^0.5.0",
     "pluralize": "^1.2.1",
     "redux-actions": "^0.9.1"

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,8 @@ import keykey from 'keykey';
 export default keykey([
   'API_SET_AXIOS_CONFIG',
   'API_HYDRATE',
+  'API_WILL_REQUEST',
+  'API_DID_REQUEST',
   'API_WILL_CREATE',
   'API_CREATED',
   'API_CREATE_FAILED',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,6 +2458,10 @@ lodash.toplainobject@^3.0.0:
     lodash._basecopy "^3.0.0"
     lodash.keysin "^3.0.0"
 
+lodash.uniqueid@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz#3268f26a7c88e4f4b1758d679271814e31fa5b26"
+
 lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"


### PR DESCRIPTION
This PR contains two things (which build on each other) but which for the purpose of explaining what's going on I will seperate:

1. There are two new actions `API_WILL_REQUEST` and `API_DID_REQUEST` which cache ALL the request data (endpoint, data, axiosConfig etc.) in the redux store before each request. This happens purely so that middleware can hook in and change stuff. The data is then immediately read out again and used for the request. After the request the request data is deleted again by using the second action. This means request options can be built from multiple sources (by order of superiority):
   1. If defined: Customisation Middleware
   2. option parameter (the second parameter of each API action)
   3. global axiosConfig (only for the axiosConfig part obviously)
   4. API-action-specific options (i.e. the `updateResource` uses the `POST` method)

1. There is now a `stateKey` property in the reducer. If this is defined and if there is a `stateKey` property in the action payload then the action is only applied if they match up. (Since this is part of the `requestOptions` (see 1.) customisation middleware can select between instances) This way it is possible to have multiple instances `redux-json-api` if needed. To make this easier to set up this PR adds a `createInstance` function which returns a reducer and actions which are bound to this instance.

This should be fully backward compatible for people who want to stick with a single instance and not bother about customisation middleware.

An example of the instance API in use:
```javascript
const { reducer: instance1Reducer, readEndpoint: readEndpoint1 } = createInstance('instance-1');
const { reducer: instance2Reducer, readEndpoint: readEndpoint2 } = createInstance('instance-2');

const store = createReduxStore(
  combineReducers({
    'instance-1': instance1Reducer,
    'instance-2': instance2Reducer
  }),
  composeEnhancers(applyMiddleware(thunk))
);

// use readEndpoint1 and 2 as you would normally ...
```

Some notes for @egeriis 
- I removed the default options parameter on the `readEndpoint` function. It was messing with the API action binding. This should not break anythin however, because there are very (strict checks in place)[https://github.com/redux-json-api/redux-json-api/blob/master/src/state-mutation.js#L100] when this is used.
- The part in each action handling in the reducer where it checks whether there is a stateKey and if it is the correct one could be refactored out into a utility function of course but I found this to be by far more readable.

… also sorry for the giant PR! 🤕 