### PR TITLE
Pagination URLs can be objects.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -59,9 +59,13 @@ export const getPaginationUrl = (response, direction, path) => {
     return null;
   }
 
-  const paginationUrl = response.links[direction];
+  let paginationUrl = response.links[direction];
   if (!paginationUrl) {
     return null;
+  }
+
+  if (hasOwnProperties(response.links[direction], ['href'])) {
+    paginationUrl = response.links[direction].href;
   }
   return paginationUrl.replace(`${path}/`, '');
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,6 +17,17 @@ const responseWithLinks = {
   }
 };
 
+const responseWithHrefLinks = {
+  links: {
+    prev: {
+      href: 'transactions/1',
+    },
+    next: {
+      href: 'transactions/3',
+    },
+  }
+};
+
 const responseWithNullLinks = {
   links: {
     prev: null,
@@ -42,6 +53,16 @@ describe('Pagination URLs', () => {
 
   it('should return a link for the next page', () => {
     const r = getPaginationUrl(responseWithLinks, 'next', path);
+    expect(r).toEqual('transactions/3');
+  });
+
+  it('should return a href link for the previous page', () => {
+    const r = getPaginationUrl(responseWithHrefLinks, 'prev', path);
+    expect(r).toEqual('transactions/1');
+  });
+
+  it('should return a href link for the next page', () => {
+    const r = getPaginationUrl(responseWithHrefLinks, 'next', path);
     expect(r).toEqual('transactions/3');
   });
 


### PR DESCRIPTION
Fixes #171
According to https://jsonapi.org/format/#document-links

> * a string containing the link’s URL.
> * an object (“link object”) which can contain the following members:
>   * `href`: a string containing the link’s URL.