### PR TITLE
Upgrade keykey

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "axios": "^0.13.1",
     "deep-equal": "^1.0.1",
-    "keykey": "^2.1.1",
+    "keykey": "^3.0.0",
     "object-path-immutable": "^0.5.0",
     "pluralize": "^1.2.1",
     "redux-actions": "^0.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,11 @@ core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
+core-js@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2228,11 +2233,13 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-keykey@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/keykey/-/keykey-2.1.1.tgz#a2739051475f4a02cc8dde23b160b37eb4fe62af"
+keykey@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keykey/-/keykey-3.0.0.tgz#ba20a0ec1d28e327f339a196451b3d3dc61ace3a"
+  integrity sha512-QX0TNJNu7/ABSftiR6l+HgrHWYMeIjNdBhwNks5I82udXBGlfArJyKiubizvDYDR3L0OtJPWx6EfpAHgQrRMUw==
   dependencies:
-    lru-cache "3.2.0"
+    core-js "^3.6.4"
+    lru-cache "^5.1.1"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -2480,11 +2487,12 @@ lru-cache@2:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-2.7.3.tgz#6d4524e8b955f95d4f5b58851ce21dd72fb4e952"
 
-lru-cache@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-3.2.0.tgz#71789b3b7f5399bec8565dda38aa30d2a097efee"
+lru-cache@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
-    pseudomap "^1.0.1"
+    yallist "^3.0.2"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -2851,10 +2859,6 @@ process@^0.11.0:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
-
-pseudomap@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -3452,6 +3456,11 @@ xml-escape@~1.0.0:
 xtend@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+yallist@^3.0.2:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
+  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
`keykey` v2.x uses a very outdated version of `lru-cache`, which is incompatible with the version used by other modern and more up-to-date packages.  This PR updates the `keykey` dependency, which includes a newer version or `lru-cache`.